### PR TITLE
#159764417 Send emails on account creation and resetting password

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -192,6 +192,23 @@ var User = function () {
 				callback(err, res);
 			});
 		}
+	}, {
+		key: 'sendNewPassword',
+		value: function sendNewPassword(req, callback) {
+			var saltRounds = 10;
+			var salt = _bcryptjs2.default.genSaltSync(saltRounds);
+			var password = 'passworddkj';
+			var hash = _bcryptjs2.default.hashSync(password, salt);
+			var sql = 'UPDATE users SET password=$1 WHERE email=$2 RETURNING email, fullname';
+			var values = [hash, req.body.email];
+			this.pool.query(sql, values, function (err, res) {
+				if (res.rows.length < 1) {
+					callback('This email does not exist on our database!', null, null);
+				} else {
+					callback(null, res, password);
+				}
+			});
+		}
 	}]);
 
 	return User;

--- a/app/routes/usersApi.js
+++ b/app/routes/usersApi.js
@@ -29,6 +29,10 @@ usersRouter.post('/auth/login', function (req, res) {
 	User.signIn(req, res);
 });
 
+usersRouter.post('/auth/forgot_password', function (req, res) {
+	User.forgotPassword(req, res);
+});
+
 usersRouter.get('/user/profile', _checkAuth2.default, function (req, res) {
 	User.show(req, res);
 });

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -149,6 +149,22 @@ class User {
 			callback(err, res);
 		});
 	}
+
+	sendNewPassword(req, callback) {
+		const saltRounds = 10;
+		const salt = bcryptjs.genSaltSync(saltRounds);
+		const password = 'passworddkj';
+		const hash = bcryptjs.hashSync(password, salt);
+		const sql = 'UPDATE users SET password=$1 WHERE email=$2 RETURNING email, fullname';
+		const values = [hash, req.body.email];
+		this.pool.query(sql, values, (err, res) => {
+			if (res.rows.length < 1) {
+				callback('This email does not exist on our database!', null, null);
+			} else {
+				callback(null, res, password);
+			}
+		});
+	}
 }
 
 export default User;

--- a/server/routes/usersApi.js
+++ b/server/routes/usersApi.js
@@ -13,6 +13,10 @@ usersRouter.post('/auth/login', (req, res) => {
 	User.signIn(req, res);
 });
 
+usersRouter.post('/auth/forgot_password', (req, res) => {
+	User.forgotPassword(req, res);
+});
+
 usersRouter.get('/user/profile', checkAuth, (req, res) => {
 	User.show(req, res);
 });


### PR DESCRIPTION
#### What does this PR do?
This pull request sends email to users on account creation and when password has been forgotten

#### Description of Task to be completed?
The following tasks have been completed:
Send notification emails to users when they signup
Send email when a user forgets his/her password with the new password included.

#### How should this be manually tested?
After cloning this repo, cd into it. Run npm install, then npm start. As a user after signup, the user should receive an email. Also when a user uses the forgot password form, their new password gets sent to them.

#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#159764417:(https://www.pivotaltracker.com/story/show/159764417), 
#### Screenshots (if appropriate)
#### Questions: